### PR TITLE
Static mem channel

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -99,7 +99,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: ["1.60.0"]
+        msrv: ["1.61.0"]
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -82,3 +82,4 @@ jobs:
         env:
           LOOM_MAX_PREEMPTIONS: 2
           RUSTFLAGS: "--cfg loom"
+          RUSTDOCFLAGS: "--cfg loom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Fast, bounded, multiple-producer, multiple-consumer, lossy, broad
 repository = "https://github.com/Amjad50/blinkcast.git"
 keywords = ["channel", "broadcast", "mpmc", "no_std"]
 categories = ["concurrency", "no-std"]
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 
 [features]
 default = ["alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ categories = ["concurrency", "no-std"]
 rust-version = "1.60.0"
 
 [features]
+default = ["alloc"]
+
+alloc = []
+# This is used only for testing using `bench`, as it requires nightly
+# doesn't provide any extra functionality
 unstable = []
 
 [target.'cfg(loom)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ up to date is better than delayed audio.
 See [the documentation](https://docs.rs/blinkcast) for examples.
 
 # Minimum Supported Rust Version (MSRV)
-The minimum supported Rust version for this crate is `1.60.0`
+The minimum supported Rust version for this crate is `1.61.0`
 
 # License
 Licensed under `MIT` ([LICENSE](./LICENSE) or http://opensource.org/licenses/MIT)

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -1,0 +1,189 @@
+//! A channel implemented with heap allocated buffers (require `alloc` feature).
+
+extern crate alloc;
+use alloc::{boxed::Box, vec::Vec};
+
+use crate::{core_impl, AtomicUsize, Node, ReaderData, MAX_LEN};
+
+#[cfg(not(loom))]
+use alloc::sync::Arc;
+#[cfg(loom)]
+use loom::sync::Arc;
+
+struct InnerChannel<T, const N: usize> {
+    buffer: Box<[Node<T>]>,
+    head: AtomicUsize,
+}
+
+impl<T: Clone, const N: usize> InnerChannel<T, N> {
+    fn new() -> Self {
+        let mut buffer = Vec::with_capacity(N);
+        for _ in 0..N {
+            buffer.push(Default::default());
+        }
+        let buffer = buffer.into_boxed_slice();
+        Self {
+            buffer,
+            head: AtomicUsize::new(0),
+        }
+    }
+
+    fn push(&self, value: T) {
+        core_impl::push(&self.buffer, &self.head, value);
+    }
+
+    fn pop(&self, reader: &mut ReaderData) -> Option<T> {
+        core_impl::pop(&self.buffer, &self.head, reader)
+    }
+}
+
+/// The sender of the [`channel`].
+///
+/// This is a cloneable sender, so you can have multiple senders that will send to the same
+/// channel.
+///
+/// Broadcast messages sent by using the [`send`](Sender::send) method.
+///
+/// # Examples
+/// ```
+/// # #[cfg(not(loom))]
+/// # {
+/// use blinkcast::alloc::channel;
+///
+/// let (sender, mut receiver) = channel::<i32, 4>();
+///
+/// sender.send(1);
+/// let sender2 = sender.clone();
+/// sender2.send(2);
+///
+/// assert_eq!(receiver.recv(), Some(1));
+/// assert_eq!(receiver.recv(), Some(2));
+/// assert_eq!(receiver.recv(), None);
+/// # }
+/// ```
+pub struct Sender<T, const N: usize> {
+    queue: Arc<InnerChannel<T, N>>,
+}
+
+unsafe impl<T: Clone + Send, const N: usize> Send for Sender<T, N> {}
+unsafe impl<T: Clone + Send, const N: usize> Sync for Sender<T, N> {}
+
+impl<T: Clone, const N: usize> Sender<T, N> {
+    /// Sends a message to the channel.
+    /// If the channel is full, the oldest message will be overwritten.
+    /// So the receiver must be quick or it will lose the old data.
+    pub fn send(&self, value: T) {
+        self.queue.push(value);
+    }
+}
+
+impl<T, const N: usize> Clone for Sender<T, N> {
+    fn clone(&self) -> Self {
+        Self {
+            queue: self.queue.clone(),
+        }
+    }
+}
+
+/// The receiver of the [`channel`].
+///
+/// This is a cloneable receiver, so you can have multiple receivers that start from the same
+/// point.
+///
+/// Broadcast messages sent by the channel are received by the [`recv`](Receiver::recv) method.
+///
+/// # Examples
+/// ```
+/// # #[cfg(not(loom))]
+/// # {
+/// use blinkcast::alloc::channel;
+/// let (sender, mut receiver) = channel::<i32, 4>();
+/// sender.send(1);
+/// assert_eq!(receiver.recv(), Some(1));
+///
+/// sender.send(2);
+/// sender.send(3);
+///
+/// assert_eq!(receiver.recv(), Some(2));
+///
+/// // clone the receiver
+/// let mut receiver2 = receiver.clone();
+/// assert_eq!(receiver.recv(), Some(3));
+/// assert_eq!(receiver2.recv(), Some(3));
+/// assert_eq!(receiver.recv(), None);
+/// assert_eq!(receiver2.recv(), None);
+/// # }
+/// ```
+pub struct Receiver<T, const N: usize> {
+    queue: Arc<InnerChannel<T, N>>,
+    reader: ReaderData,
+}
+
+unsafe impl<T: Clone + Send, const N: usize> Send for Receiver<T, N> {}
+unsafe impl<T: Clone + Send, const N: usize> Sync for Receiver<T, N> {}
+
+impl<T: Clone, const N: usize> Receiver<T, N> {
+    /// Receives a message from the channel.
+    ///
+    /// If there is no message available, this method will return `None`.
+    pub fn recv(&mut self) -> Option<T> {
+        self.queue.pop(&mut self.reader)
+    }
+}
+
+impl<T: Clone, const N: usize> Clone for Receiver<T, N> {
+    fn clone(&self) -> Self {
+        Self {
+            queue: self.queue.clone(),
+            reader: self.reader.clone(),
+        }
+    }
+}
+
+/// Creates a new channel, returning the [`Sender`] and [`Receiver`] for it.
+///
+/// Both of the sender and receiver are cloneable, so you can have multiple senders and receivers.
+///
+/// # Examples
+/// ```
+/// # #[cfg(not(loom))]
+/// # {
+/// use blinkcast::alloc::channel;
+/// let (sender, mut receiver) = channel::<i32, 4>();
+///
+/// sender.send(1);
+/// sender.send(2);
+///
+/// assert_eq!(receiver.recv(), Some(1));
+///
+/// let sender2 = sender.clone();
+/// sender2.send(3);
+///
+/// assert_eq!(receiver.recv(), Some(2));
+///
+/// let mut receiver2 = receiver.clone();
+/// assert_eq!(receiver.recv(), Some(3));
+/// assert_eq!(receiver2.recv(), Some(3));
+/// assert_eq!(receiver.recv(), None);
+/// assert_eq!(receiver2.recv(), None);
+/// # }
+/// ```
+pub fn channel<T: Clone, const N: usize>() -> (Sender<T, N>, Receiver<T, N>) {
+    // TODO: replace with compile time assert
+    assert!(
+        N <= MAX_LEN,
+        "The buffer size must be less than {}",
+        MAX_LEN
+    );
+
+    let queue = Arc::new(InnerChannel::<T, N>::new());
+    (
+        Sender {
+            queue: queue.clone(),
+        },
+        Receiver {
+            queue,
+            reader: ReaderData { index: 0, lap: 0 },
+        },
+    )
+}

--- a/src/core_impl.rs
+++ b/src/core_impl.rs
@@ -1,0 +1,176 @@
+use core::cmp;
+
+use crate::{
+    is_readable, is_reading, pack_data_index, unpack_data_index, AtomicUsize, MaybeUninit, Node,
+    Ordering, ReaderData, STATE_AVAILABLE, STATE_EMPTY, STATE_READING, STATE_WRITING,
+};
+
+pub(crate) fn push<T>(buffer: &[Node<T>], head: &AtomicUsize, value: T) {
+    let mut node;
+    let mut should_drop;
+
+    let mut current_head = head.load(Ordering::Acquire);
+
+    loop {
+        let (mut producer_lap, mut producer_index) = unpack_data_index(current_head);
+
+        node = &buffer[producer_index % buffer.len()];
+
+        // acquire the node
+        let mut state;
+        loop {
+            state = node.state.load(Ordering::Acquire);
+
+            while is_reading(state) {
+                core::hint::spin_loop();
+                // wait until the reader is done
+                state = node.state.load(Ordering::Acquire);
+            }
+
+            match state {
+                STATE_EMPTY | STATE_AVAILABLE => {
+                    if node
+                        .state
+                        .compare_exchange_weak(
+                            state,
+                            STATE_WRITING,
+                            Ordering::AcqRel,
+                            Ordering::Relaxed,
+                        )
+                        .is_ok()
+                    {
+                        should_drop = state == STATE_AVAILABLE;
+                        break;
+                    }
+                }
+                STATE_WRITING => {
+                    // move to next position
+                    producer_index += 1;
+                    if producer_index == 0 {
+                        producer_lap += 1;
+                    }
+                    current_head = pack_data_index(producer_lap, producer_index);
+                    node = &buffer[producer_index % buffer.len()];
+                }
+                s => unreachable!("Invalid state: {}", s),
+            }
+        }
+
+        let next_index = (producer_index + 1) % buffer.len();
+        let next_lap = if next_index == 0 {
+            producer_lap + 1
+        } else {
+            producer_lap
+        };
+        let next_head = pack_data_index(next_lap, next_index);
+
+        match head.compare_exchange(current_head, next_head, Ordering::AcqRel, Ordering::Relaxed) {
+            Ok(_) => {
+                node.lap.set(producer_lap);
+                break;
+            }
+            Err(x) => {
+                current_head = x;
+            }
+        }
+        // rollback and try again
+        node.state.store(state, Ordering::Release);
+    }
+
+    if should_drop {
+        // Safety: we have exclusive access to the node
+        unsafe {
+            node.data.get().read().assume_init_drop();
+        }
+    }
+
+    // Safety: we have exclusive access to the node
+    unsafe {
+        node.data.get().write(MaybeUninit::new(value));
+    }
+    // release the node
+    node.state.store(STATE_AVAILABLE, Ordering::Release);
+}
+
+pub(crate) fn pop<T: Clone>(
+    buffer: &[Node<T>],
+    head: &AtomicUsize,
+    reader: &mut ReaderData,
+) -> Option<T> {
+    let (producer_lap, producer_index) = unpack_data_index(head.load(Ordering::Acquire));
+    let mut reader_index = reader.index;
+    let reader_lap = reader.lap;
+
+    match reader_lap.cmp(&producer_lap) {
+        // the reader is before the writer
+        // so there must be something to read
+        cmp::Ordering::Less => {
+            let lap_diff = producer_lap - reader_lap;
+            let head_diff = producer_index as isize - reader_index as isize;
+
+            if (lap_diff > 0 && head_diff > 0) || lap_diff > 1 {
+                // there is an overflow
+                // we need to update the reader index
+                // we will take the latest readable value, the furthest from the writer
+                // and this is the value at [head, producer_lap - 1]
+                let new_index = producer_index % buffer.len();
+                reader_index = new_index;
+
+                reader.lap = producer_lap - 1;
+            }
+        }
+        cmp::Ordering::Equal => {
+            if reader_index >= producer_index {
+                return None;
+            }
+        }
+        cmp::Ordering::Greater => {
+            unreachable!("The reader is after the writer");
+        }
+    }
+    let mut node = &buffer[reader_index % buffer.len()];
+
+    // acquire the node
+    loop {
+        let state = node.state.load(Ordering::Acquire);
+
+        if is_readable(state) {
+            let old = node.state.fetch_add(STATE_READING, Ordering::AcqRel);
+
+            if is_readable(old) {
+                break;
+            }
+            // something happened, rollback
+            node.state.fetch_sub(STATE_READING, Ordering::Release);
+            continue;
+        }
+
+        match state {
+            STATE_WRITING => {
+                reader_index += 1;
+                node = &buffer[reader_index % buffer.len()];
+            }
+            STATE_EMPTY => unreachable!("There should be some data at least"),
+            s => unreachable!("Invalid state: {}", s),
+        }
+    }
+
+    // if the node contain a different lap number, then the writer
+    // has overwritten the data and finished writing before we got the lock
+    // retry the whole thing (slow)
+    if node.lap.get() != reader.lap {
+        node.state.fetch_sub(STATE_READING, Ordering::Release);
+        return pop(buffer, head, reader);
+    }
+
+    let data = unsafe { node.data.get().read().assume_init_ref().clone() };
+
+    reader.index = (reader_index + 1) % buffer.len();
+    if reader.index == 0 {
+        reader.lap += 1;
+    }
+
+    node.state.fetch_sub(STATE_READING, Ordering::Release);
+
+    Some(data)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,10 @@ mod tests;
 #[cfg(feature = "alloc")]
 pub mod alloc;
 mod core_impl;
+#[cfg(not(loom))]
+// Atomics in `loom` don't support `const fn`, so it crashes when compiling
+// since, we don't need `static_mem` to be tested with `loom`, we can just
+// exclude it if we are building for `loom`
 pub mod static_mem;
 
 // choose 64 for targets that support it, otherwise 32
@@ -154,6 +158,10 @@ struct Node<T> {
 }
 
 impl<T> Node<T> {
+    #[cfg(not(loom))]
+    // Atomics in `loom` don't support `const fn`, so it crashes when compiling
+    // since, we don't need `static_mem` to be tested with `loom`, we can just
+    // exclude it if we are building for `loom`
     pub const fn empty() -> Self {
         Self {
             data: UnsafeCell::new(MaybeUninit::uninit()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,9 @@ const LAP_SHIFT: u8 = 32;
 const LAP_SHIFT: u8 = 16;
 
 const INDEX_MASK: usize = (1 << LAP_SHIFT) - 1;
-const MAX_LEN: usize = INDEX_MASK;
+/// The maximum length of the buffer allowed on this platform
+/// It will be `2^16 - 1` on 32bit platforms and `2^32 - 1` on 64bit platforms
+pub const MAX_LEN: usize = INDEX_MASK;
 
 const STATE_EMPTY: usize = 0;
 const STATE_AVAILABLE: usize = 1;
@@ -149,6 +151,16 @@ struct Node<T> {
     data: UnsafeCell<MaybeUninit<T>>,
     state: AtomicUsize,
     lap: Cell<usize>,
+}
+
+impl<T> Node<T> {
+    pub const fn empty() -> Self {
+        Self {
+            data: UnsafeCell::new(MaybeUninit::uninit()),
+            state: AtomicUsize::new(STATE_EMPTY),
+            lap: Cell::new(0),
+        }
+    }
 }
 
 impl<T> Default for Node<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! # {
 //! use blinkcast::alloc::channel;
 //!
-//! let (sender, mut receiver1) = channel::<i32, 4>();
+//! let (sender, mut receiver1) = channel::<i32>(4);
 //! sender.send(1);
 //! sender.send(2);
 //!
@@ -48,7 +48,7 @@
 //! # {
 //! use blinkcast::alloc::channel;
 //! use std::thread;
-//! let (sender1, mut receiver1) = channel::<i32, 100>();
+//! let (sender1, mut receiver1) = channel::<i32>(100);
 //! let sender2 = sender1.clone();
 //!
 //! let t1 = thread::spawn(move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@
 //! # Example
 //! Single sender multiple receivers
 //! ```
-//! # #[cfg(loom)]
-//! # loom::model(|| {
-//! use blinkcast::channel;
+//! # #[cfg(not(loom))]
+//! # {
+//! use blinkcast::alloc::channel;
 //!
 //! let (sender, mut receiver1) = channel::<i32, 4>();
 //! sender.send(1);
@@ -40,13 +40,13 @@
 //! assert_eq!(receiver2.recv(), Some(1));
 //! assert_eq!(receiver2.recv(), Some(2));
 //! assert_eq!(receiver2.recv(), None);
-//! # });
+//! # }
 //! ```
 //! Multiple senders multiple receivers
 //! ```
-//! # #[cfg(loom)]
-//! # loom::model(|| {
-//! use blinkcast::channel;
+//! # #[cfg(not(loom))]
+//! # {
+//! use blinkcast::alloc::channel;
 //! use std::thread;
 //! let (sender1, mut receiver1) = channel::<i32, 100>();
 //! let sender2 = sender1.clone();
@@ -78,34 +78,29 @@
 //! }
 //! assert_eq!(sum1, 49 * 50);
 //! assert_eq!(sum2, 49 * 50);
-//! # });
+//! # }
 //! ```
 
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 
-#[cfg(test)]
-mod tests;
-
-extern crate alloc;
-use alloc::{boxed::Box, vec::Vec};
-
 use core::{
     cell::{Cell, UnsafeCell},
-    cmp,
     mem::MaybeUninit,
 };
 
-#[cfg(loom)]
-use loom::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
-};
-
-#[cfg(not(loom))]
-use alloc::sync::Arc;
 #[cfg(not(loom))]
 use core::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(loom)]
+use loom::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(feature = "alloc")]
+pub mod alloc;
+mod core_impl;
+pub mod static_mem;
 
 // choose 64 for targets that support it, otherwise 32
 #[cfg(target_pointer_width = "64")]
@@ -170,344 +165,4 @@ impl<T> Default for Node<T> {
 struct ReaderData {
     index: usize,
     lap: usize,
-}
-
-struct InnerChannel<T, const N: usize> {
-    buffer: Box<[Node<T>]>,
-    head: AtomicUsize,
-}
-
-impl<T: Clone, const N: usize> InnerChannel<T, N> {
-    fn new() -> Self {
-        let mut buffer = Vec::with_capacity(N);
-        for _ in 0..N {
-            buffer.push(Default::default());
-        }
-        let buffer = buffer.into_boxed_slice();
-        Self {
-            buffer,
-            head: AtomicUsize::new(0),
-        }
-    }
-
-    fn push(&self, value: T) {
-        let mut node;
-        let mut should_drop;
-
-        let mut current_head = self.head.load(Ordering::Acquire);
-
-        loop {
-            let (mut producer_lap, mut producer_index) = unpack_data_index(current_head);
-
-            node = &self.buffer[producer_index % self.buffer.len()];
-
-            // acquire the node
-            let mut state;
-            loop {
-                state = node.state.load(Ordering::Acquire);
-
-                while is_reading(state) {
-                    core::hint::spin_loop();
-                    // wait until the reader is done
-                    state = node.state.load(Ordering::Acquire);
-                }
-
-                match state {
-                    STATE_EMPTY | STATE_AVAILABLE => {
-                        if node
-                            .state
-                            .compare_exchange_weak(
-                                state,
-                                STATE_WRITING,
-                                Ordering::AcqRel,
-                                Ordering::Relaxed,
-                            )
-                            .is_ok()
-                        {
-                            should_drop = state == STATE_AVAILABLE;
-                            break;
-                        }
-                    }
-                    STATE_WRITING => {
-                        // move to next position
-                        producer_index += 1;
-                        if producer_index == 0 {
-                            producer_lap += 1;
-                        }
-                        current_head = pack_data_index(producer_lap, producer_index);
-                        node = &self.buffer[producer_index % self.buffer.len()];
-                    }
-                    s => unreachable!("Invalid state: {}", s),
-                }
-            }
-
-            let next_index = (producer_index + 1) % self.buffer.len();
-            let next_lap = if next_index == 0 {
-                producer_lap + 1
-            } else {
-                producer_lap
-            };
-            let next_head = pack_data_index(next_lap, next_index);
-
-            match self.head.compare_exchange(
-                current_head,
-                next_head,
-                Ordering::AcqRel,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => {
-                    node.lap.set(producer_lap);
-                    break;
-                }
-                Err(x) => {
-                    current_head = x;
-                }
-            }
-            // rollback and try again
-            node.state.store(state, Ordering::Release);
-        }
-
-        if should_drop {
-            // Safety: we have exclusive access to the node
-            unsafe {
-                node.data.get().read().assume_init_drop();
-            }
-        }
-
-        // Safety: we have exclusive access to the node
-        unsafe {
-            node.data.get().write(MaybeUninit::new(value));
-        }
-        // release the node
-        node.state.store(STATE_AVAILABLE, Ordering::Release);
-    }
-
-    fn pop(&self, reader: &mut ReaderData) -> Option<T> {
-        let (producer_lap, producer_index) = unpack_data_index(self.head.load(Ordering::Acquire));
-        let mut reader_index = reader.index;
-        let reader_lap = reader.lap;
-
-        match reader_lap.cmp(&producer_lap) {
-            // the reader is before the writer
-            // so there must be something to read
-            cmp::Ordering::Less => {
-                let lap_diff = producer_lap - reader_lap;
-                let head_diff = producer_index as isize - reader_index as isize;
-
-                if (lap_diff > 0 && head_diff > 0) || lap_diff > 1 {
-                    // there is an overflow
-                    // we need to update the reader index
-                    // we will take the latest readable value, the furthest from the writer
-                    // and this is the value at [head, producer_lap - 1]
-                    let new_index = producer_index % self.buffer.len();
-                    reader_index = new_index;
-
-                    reader.lap = producer_lap - 1;
-                }
-            }
-            cmp::Ordering::Equal => {
-                if reader_index >= producer_index {
-                    return None;
-                }
-            }
-            cmp::Ordering::Greater => {
-                unreachable!("The reader is after the writer");
-            }
-        }
-        let mut node = &self.buffer[reader_index % self.buffer.len()];
-
-        // acquire the node
-        loop {
-            let state = node.state.load(Ordering::Acquire);
-
-            if is_readable(state) {
-                let old = node.state.fetch_add(STATE_READING, Ordering::AcqRel);
-
-                if is_readable(old) {
-                    break;
-                }
-                // something happened, rollback
-                node.state.fetch_sub(STATE_READING, Ordering::Release);
-                continue;
-            }
-
-            match state {
-                STATE_WRITING => {
-                    reader_index += 1;
-                    node = &self.buffer[reader_index % self.buffer.len()];
-                }
-                STATE_EMPTY => unreachable!("There should be some data at least"),
-                s => unreachable!("Invalid state: {}", s),
-            }
-        }
-
-        // if the node contain a different lap number, then the writer
-        // has overwritten the data and finished writing before we got the lock
-        // retry the whole thing (slow)
-        if node.lap.get() != reader.lap {
-            node.state.fetch_sub(STATE_READING, Ordering::Release);
-            return self.pop(reader);
-        }
-
-        let data = unsafe { node.data.get().read().assume_init_ref().clone() };
-
-        reader.index = (reader_index + 1) % self.buffer.len();
-        if reader.index == 0 {
-            reader.lap += 1;
-        }
-
-        node.state.fetch_sub(STATE_READING, Ordering::Release);
-
-        Some(data)
-    }
-}
-
-/// The sender of the [`channel`].
-///
-/// This is a cloneable sender, so you can have multiple senders that will send to the same
-/// channel.
-///
-/// Broadcast messages sent by using the [`send`](Sender::send) method.
-///
-/// # Examples
-/// ```
-/// # #[cfg(loom)]
-/// # loom::model(|| {
-/// use blinkcast::channel;
-///
-/// let (sender, mut receiver) = channel::<i32, 4>();
-///
-/// sender.send(1);
-/// let sender2 = sender.clone();
-/// sender2.send(2);
-///
-/// assert_eq!(receiver.recv(), Some(1));
-/// assert_eq!(receiver.recv(), Some(2));
-/// assert_eq!(receiver.recv(), None);
-/// # });
-pub struct Sender<T, const N: usize> {
-    queue: Arc<InnerChannel<T, N>>,
-}
-
-unsafe impl<T: Clone + Send, const N: usize> Send for Sender<T, N> {}
-unsafe impl<T: Clone + Send, const N: usize> Sync for Sender<T, N> {}
-
-impl<T: Clone, const N: usize> Sender<T, N> {
-    /// Sends a message to the channel.
-    /// If the channel is full, the oldest message will be overwritten.
-    /// So the receiver must be quick or it will lose the old data.
-    pub fn send(&self, value: T) {
-        self.queue.push(value);
-    }
-}
-
-impl<T, const N: usize> Clone for Sender<T, N> {
-    fn clone(&self) -> Self {
-        Self {
-            queue: self.queue.clone(),
-        }
-    }
-}
-
-/// The receiver of the [`channel`].
-///
-/// This is a cloneable receiver, so you can have multiple receivers that start from the same
-/// point.
-///
-/// Broadcast messages sent by the channel are received by the [`recv`](Receiver::recv) method.
-///
-/// # Examples
-/// ```
-/// # #[cfg(loom)]
-/// # loom::model(|| {
-/// use blinkcast::channel;
-/// let (sender, mut receiver) = channel::<i32, 4>();
-/// sender.send(1);
-/// assert_eq!(receiver.recv(), Some(1));
-///
-/// sender.send(2);
-/// sender.send(3);
-///
-/// assert_eq!(receiver.recv(), Some(2));
-///
-/// // clone the receiver
-/// let mut receiver2 = receiver.clone();
-/// assert_eq!(receiver.recv(), Some(3));
-/// assert_eq!(receiver2.recv(), Some(3));
-/// assert_eq!(receiver.recv(), None);
-/// assert_eq!(receiver2.recv(), None);
-/// # });
-/// ```
-pub struct Receiver<T, const N: usize> {
-    queue: Arc<InnerChannel<T, N>>,
-    reader: ReaderData,
-}
-
-unsafe impl<T: Clone + Send, const N: usize> Send for Receiver<T, N> {}
-unsafe impl<T: Clone + Send, const N: usize> Sync for Receiver<T, N> {}
-
-impl<T: Clone, const N: usize> Receiver<T, N> {
-    /// Receives a message from the channel.
-    ///
-    /// If there is no message available, this method will return `None`.
-    pub fn recv(&mut self) -> Option<T> {
-        self.queue.pop(&mut self.reader)
-    }
-}
-
-impl<T: Clone, const N: usize> Clone for Receiver<T, N> {
-    fn clone(&self) -> Self {
-        Self {
-            queue: self.queue.clone(),
-            reader: self.reader.clone(),
-        }
-    }
-}
-
-/// Creates a new channel, returning the [`Sender`] and [`Receiver`] for it.
-///
-/// Both of the sender and receiver are cloneable, so you can have multiple senders and receivers.
-///
-/// # Examples
-/// ```
-/// # #[cfg(loom)]
-/// # loom::model(|| {
-/// use blinkcast::channel;
-/// let (sender, mut receiver) = channel::<i32, 4>();
-///
-/// sender.send(1);
-/// sender.send(2);
-///
-/// assert_eq!(receiver.recv(), Some(1));
-///
-/// let sender2 = sender.clone();
-/// sender2.send(3);
-///
-/// assert_eq!(receiver.recv(), Some(2));
-///
-/// let mut receiver2 = receiver.clone();
-/// assert_eq!(receiver.recv(), Some(3));
-/// assert_eq!(receiver2.recv(), Some(3));
-/// assert_eq!(receiver.recv(), None);
-/// assert_eq!(receiver2.recv(), None);
-/// # });
-/// ```
-pub fn channel<T: Clone, const N: usize>() -> (Sender<T, N>, Receiver<T, N>) {
-    // TODO: replace with compile time assert
-    assert!(
-        N <= MAX_LEN,
-        "The buffer size must be less than {}",
-        MAX_LEN
-    );
-
-    let queue = Arc::new(InnerChannel::<T, N>::new());
-    (
-        Sender {
-            queue: queue.clone(),
-        },
-        Receiver {
-            queue,
-            reader: ReaderData { index: 0, lap: 0 },
-        },
-    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,27 @@
 //! assert_eq!(sum2, 49 * 50);
 //! # }
 //! ```
+//! Another example using the [`static_mem`] module (no allocation)
+//! ```
+//! # #[cfg(not(loom))]
+//! # {
+//! use blinkcast::static_mem::Sender;
+//!
+//! let sender = Sender::<i32, 4>::new();
+//! let mut receiver1 = sender.new_receiver();
+//! sender.send(1);
+//! sender.send(2);
+//!
+//! let mut receiver2 = receiver1.clone();
+//!
+//! assert_eq!(receiver1.recv(), Some(1));
+//! assert_eq!(receiver1.recv(), Some(2));
+//! assert_eq!(receiver1.recv(), None);
+//!
+//! assert_eq!(receiver2.recv(), Some(1));
+//! assert_eq!(receiver2.recv(), Some(2));
+//! assert_eq!(receiver2.recv(), None);
+//! # }
 
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]

--- a/src/static_mem.rs
+++ b/src/static_mem.rs
@@ -1,0 +1,199 @@
+//! A channel implemented with static memory.
+
+use crate::{
+    core_impl, unpack_data_index, AtomicUsize, MaybeUninit, Node, Ordering, ReaderData, MAX_LEN,
+};
+
+struct InnerChannel<T, const N: usize> {
+    buffer: [Node<T>; N],
+    head: AtomicUsize,
+}
+
+impl<T: Clone + Sized, const N: usize> InnerChannel<T, N> {
+    fn new() -> Self {
+        // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
+        // safe because the type we are claiming to have initialized here is a
+        // bunch of `MaybeUninit`s, which do not require initialization
+        let mut uninit_buffer: [MaybeUninit<Node<T>>; N] =
+            unsafe { MaybeUninit::uninit().assume_init() };
+
+        for data in uninit_buffer.iter_mut() {
+            data.write(Node::default());
+        }
+
+        // Safety: we have initialized all the elements
+        // This transmute_copy will copy again, not sure if it can be optimized by the compiler
+        // but this is still an open issue (transmute doesn't work): https://github.com/rust-lang/rust/issues/61956
+        // or use `MaybeUninit::array_assume_init` when it is stabilized
+        let buffer = unsafe { core::mem::transmute_copy::<_, [Node<T>; N]>(&uninit_buffer) };
+
+        Self {
+            buffer,
+            head: AtomicUsize::new(0),
+        }
+    }
+
+    fn push(&self, value: T) {
+        core_impl::push(&self.buffer, &self.head, value);
+    }
+
+    fn pop(&self, reader: &mut ReaderData) -> Option<T> {
+        core_impl::pop(&self.buffer, &self.head, reader)
+    }
+}
+
+/// The sender of the channel.
+///
+/// This is a the main channel component, as this is stored in static memory,
+/// The `Sender` is the owner of the memory.
+/// You can use it from multiple locations by storing it in a `static` variable.
+///
+/// Then, use [`new_receiver`](Sender::new_receiver) to create a receiver.
+/// It will start from the same point as the sender.
+///
+/// Broadcast messages sent by using the [`send`](Sender::send) method.
+///
+/// # Examples
+/// ```
+/// # #[cfg(not(loom))]
+/// # {
+/// use blinkcast::static_mem::Sender;
+///
+/// let sender = Sender::<i32, 4>::new();
+/// let mut receiver = sender.new_receiver();
+///
+/// sender.send(1);
+/// sender.send(2);
+///
+/// assert_eq!(receiver.recv(), Some(1));
+/// assert_eq!(receiver.recv(), Some(2));
+/// assert_eq!(receiver.recv(), None);
+/// # }
+/// ```
+pub struct Sender<T, const N: usize> {
+    queue: InnerChannel<T, N>,
+}
+
+unsafe impl<T: Clone + Send, const N: usize> Send for Sender<T, N> {}
+unsafe impl<T: Clone + Send, const N: usize> Sync for Sender<T, N> {}
+
+impl<T: Clone, const N: usize> Sender<T, N> {
+    /// Sends a message to the channel.
+    /// If the channel is full, the oldest message will be overwritten.
+    /// So the receiver must be quick or it will lose the old data.
+    pub fn send(&self, value: T) {
+        self.queue.push(value);
+    }
+}
+
+impl<T: Clone, const N: usize> Sender<T, N> {
+    /// Creates a new channel with a buffer of size `N`.
+    pub fn new() -> Self {
+        // TODO: replace with compile time assert
+        assert!(
+            N <= MAX_LEN,
+            "The buffer size must be less than {}",
+            MAX_LEN
+        );
+
+        Self {
+            queue: InnerChannel::<T, N>::new(),
+        }
+    }
+
+    /// Creates a new receiver that starts from the same point as the sender.
+    ///
+    /// # Examples
+    /// ```
+    /// # #[cfg(not(loom))]
+    /// # {
+    /// use blinkcast::static_mem::Sender;
+    ///
+    /// let sender = Sender::<i32, 4>::new();
+    ///
+    /// sender.send(1);
+    ///
+    /// let mut receiver = sender.new_receiver();
+    /// assert_eq!(receiver.recv(), None);
+    ///
+    /// sender.send(2);
+    /// assert_eq!(receiver.recv(), Some(2));
+    /// assert_eq!(receiver.recv(), None);
+    /// # }
+    /// ```
+    pub fn new_receiver(&self) -> Receiver<'_, T, N> {
+        let head = self.queue.head.load(Ordering::Relaxed);
+        let (lap, index) = unpack_data_index(head);
+
+        Receiver {
+            queue: &self.queue,
+            reader: ReaderData { index, lap },
+        }
+    }
+}
+
+impl<T: Clone, const N: usize> Default for Sender<T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The receiver of the channel.
+///
+/// Can be created with the [`new_receiver`](Sender::new_receiver) method of the [`Sender`].
+///
+/// This is a cloneable receiver, so you can have multiple receivers that start from the same
+/// point.
+///
+/// Broadcast messages sent by the channel are received by the [`recv`](Receiver::recv) method.
+///
+/// # Examples
+/// ```
+/// # #[cfg(not(loom))]
+/// # {
+/// use blinkcast::static_mem::Sender;
+///
+/// let sender = Sender::<i32, 4>::new();
+/// let mut receiver = sender.new_receiver();
+///
+/// sender.send(1);
+/// assert_eq!(receiver.recv(), Some(1));
+///
+/// sender.send(2);
+/// sender.send(3);
+///
+/// assert_eq!(receiver.recv(), Some(2));
+///
+/// // clone the receiver
+/// let mut receiver2 = receiver.clone();
+/// assert_eq!(receiver.recv(), Some(3));
+/// assert_eq!(receiver2.recv(), Some(3));
+/// assert_eq!(receiver.recv(), None);
+/// assert_eq!(receiver2.recv(), None);
+/// # }
+/// ```
+pub struct Receiver<'a, T, const N: usize> {
+    queue: &'a InnerChannel<T, N>,
+    reader: ReaderData,
+}
+
+unsafe impl<T: Clone + Send, const N: usize> Send for Receiver<'_, T, N> {}
+unsafe impl<T: Clone + Send, const N: usize> Sync for Receiver<'_, T, N> {}
+
+impl<T: Clone, const N: usize> Receiver<'_, T, N> {
+    /// Receives a message from the channel.
+    ///
+    /// If there is no message available, this method will return `None`.
+    pub fn recv(&mut self) -> Option<T> {
+        self.queue.pop(&mut self.reader)
+    }
+}
+
+impl<T: Clone, const N: usize> Clone for Receiver<'_, T, N> {
+    fn clone(&self) -> Self {
+        Self {
+            queue: self.queue,
+            reader: self.reader.clone(),
+        }
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,14 +21,14 @@ macro_rules! loom {
 #[should_panic]
 fn test_channel_too_large() {
     loom!({
-        let _ = alloc_impl::channel::<i32, { MAX_LEN + 1 }>();
+        let _ = alloc_impl::channel::<i32>(MAX_LEN + 1);
     });
 }
 
 #[test]
 fn test_push_pop() {
     loom!({
-        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32>(4);
 
         sender.send(1);
         sender.send(2);
@@ -46,7 +46,7 @@ fn test_push_pop() {
 #[test]
 fn test_more_push_pop() {
     loom!({
-        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32>(4);
 
         sender.send(1);
         sender.send(2);
@@ -70,7 +70,7 @@ fn test_more_push_pop() {
 #[test]
 fn test_clone_send() {
     loom!({
-        let (sender, mut receiver) = alloc_impl::channel::<i32, 6>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32>(6);
 
         sender.send(1);
         sender.send(2);
@@ -95,7 +95,7 @@ fn test_clone_send() {
 #[test]
 fn test_clone_recv() {
     loom!({
-        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32>(4);
 
         sender.send(1);
         sender.send(2);
@@ -120,7 +120,7 @@ fn test_clone_recv() {
 #[test]
 fn test_middle_clone() {
     loom!({
-        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32>(4);
 
         sender.send(1);
         sender.send(2);
@@ -151,7 +151,7 @@ fn test_middle_clone() {
 #[test]
 fn test_overflow() {
     loom!({
-        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32>(4);
 
         sender.send(1);
         sender.send(2);
@@ -183,7 +183,7 @@ fn test_overflow() {
 // FIXME: spin panic on loom
 #[cfg(not(loom))]
 fn test_always_overflow() {
-    let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
+    let (sender, mut receiver) = alloc_impl::channel::<i32>(4);
 
     for i in 0..100 {
         sender.send(i);
@@ -199,7 +199,7 @@ fn test_always_overflow() {
 // FIXME: spin panic on loom
 #[cfg(not(loom))]
 fn test_sender_receiver_conflict() {
-    let (sender, receiver) = alloc_impl::channel::<i32, 4>();
+    let (sender, receiver) = alloc_impl::channel::<i32>(4);
 
     let barrier = Arc::new(std::sync::Barrier::new(2));
 
@@ -241,7 +241,7 @@ fn test_sender_receiver_conflict() {
 // FIXME: too long on loom
 #[cfg(not(loom))]
 fn test_multiple_sender_conflict() {
-    let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
+    let (sender, mut receiver) = alloc_impl::channel::<i32>(4);
 
     let barrier = Arc::new(std::sync::Barrier::new(8));
 
@@ -291,7 +291,7 @@ fn test_drop() {
             }
         }
 
-        let (sender, mut receiver) = alloc_impl::channel::<DropCount, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<DropCount>(4);
 
         sender.send(DropCount);
         sender.send(DropCount);
@@ -321,7 +321,7 @@ fn test_drop() {
 #[test]
 #[cfg(not(loom))]
 fn stress_test() {
-    let (sender, receiver) = alloc_impl::channel::<i32, 40>();
+    let (sender, receiver) = alloc_impl::channel::<i32>(40);
 
     for _ in 0..4 {
         for i in 0..10 {
@@ -355,7 +355,7 @@ mod bench {
 
     #[bench]
     fn bench_push_pop(b: &mut Bencher) {
-        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32>(4);
 
         b.iter(|| {
             sender.send(1);
@@ -389,7 +389,7 @@ mod bench {
 
     #[bench]
     fn bench_push_pop_threaded(b: &mut Bencher) {
-        let (sender, receiver) = alloc_impl::channel::<i32, 4>();
+        let (sender, receiver) = alloc_impl::channel::<i32>(4);
 
         b.iter(|| {
             let sender = sender.clone();
@@ -416,7 +416,7 @@ mod bench {
 
     #[bench]
     fn bench_overflow(b: &mut Bencher) {
-        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32>(4);
 
         b.iter(|| {
             sender.send(1);
@@ -447,7 +447,7 @@ mod bench {
 
     #[bench]
     fn bench_always_overflow(b: &mut Bencher) {
-        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32>(4);
 
         b.iter(|| {
             for i in 0..50 {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,8 @@
-use super::*;
+use super::{alloc as alloc_impl, AtomicUsize, Ordering, MAX_LEN};
+
+extern crate alloc;
+#[cfg(not(loom))]
+use alloc::sync::Arc;
 
 macro_rules! loom {
     ($b:block) => {
@@ -17,14 +21,14 @@ macro_rules! loom {
 #[should_panic]
 fn test_channel_too_large() {
     loom!({
-        let _ = channel::<i32, { MAX_LEN + 1 }>();
+        let _ = alloc_impl::channel::<i32, { MAX_LEN + 1 }>();
     });
 }
 
 #[test]
 fn test_push_pop() {
     loom!({
-        let (sender, mut receiver) = channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
 
         sender.send(1);
         sender.send(2);
@@ -42,7 +46,7 @@ fn test_push_pop() {
 #[test]
 fn test_more_push_pop() {
     loom!({
-        let (sender, mut receiver) = channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
 
         sender.send(1);
         sender.send(2);
@@ -66,7 +70,7 @@ fn test_more_push_pop() {
 #[test]
 fn test_clone_send() {
     loom!({
-        let (sender, mut receiver) = channel::<i32, 6>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32, 6>();
 
         sender.send(1);
         sender.send(2);
@@ -91,7 +95,7 @@ fn test_clone_send() {
 #[test]
 fn test_clone_recv() {
     loom!({
-        let (sender, mut receiver) = channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
 
         sender.send(1);
         sender.send(2);
@@ -116,7 +120,7 @@ fn test_clone_recv() {
 #[test]
 fn test_middle_clone() {
     loom!({
-        let (sender, mut receiver) = channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
 
         sender.send(1);
         sender.send(2);
@@ -147,7 +151,7 @@ fn test_middle_clone() {
 #[test]
 fn test_overflow() {
     loom!({
-        let (sender, mut receiver) = channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
 
         sender.send(1);
         sender.send(2);
@@ -179,7 +183,7 @@ fn test_overflow() {
 // FIXME: spin panic on loom
 #[cfg(not(loom))]
 fn test_always_overflow() {
-    let (sender, mut receiver) = channel::<i32, 4>();
+    let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
 
     for i in 0..100 {
         sender.send(i);
@@ -195,11 +199,11 @@ fn test_always_overflow() {
 // FIXME: spin panic on loom
 #[cfg(not(loom))]
 fn test_sender_receiver_conflict() {
-    let (sender, receiver) = channel::<i32, 4>();
+    let (sender, receiver) = alloc_impl::channel::<i32, 4>();
 
     let barrier = Arc::new(std::sync::Barrier::new(2));
 
-    for _ in 0..10 {
+    for _ in 0..5 {
         // setup
         // fill the channel
         for i in 0..4 {
@@ -237,7 +241,7 @@ fn test_sender_receiver_conflict() {
 // FIXME: too long on loom
 #[cfg(not(loom))]
 fn test_multiple_sender_conflict() {
-    let (sender, mut receiver) = channel::<i32, 4>();
+    let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
 
     let barrier = Arc::new(std::sync::Barrier::new(8));
 
@@ -287,7 +291,7 @@ fn test_drop() {
             }
         }
 
-        let (sender, mut receiver) = channel::<DropCount, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<DropCount, 4>();
 
         sender.send(DropCount);
         sender.send(DropCount);
@@ -317,7 +321,7 @@ fn test_drop() {
 #[test]
 #[cfg(not(loom))]
 fn stress_test() {
-    let (sender, receiver) = channel::<i32, 40>();
+    let (sender, receiver) = alloc_impl::channel::<i32, 40>();
 
     for _ in 0..4 {
         for i in 0..10 {
@@ -351,7 +355,7 @@ mod bench {
 
     #[bench]
     fn bench_push_pop(b: &mut Bencher) {
-        let (sender, mut receiver) = channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
 
         b.iter(|| {
             sender.send(1);
@@ -385,7 +389,7 @@ mod bench {
 
     #[bench]
     fn bench_push_pop_threaded(b: &mut Bencher) {
-        let (sender, receiver) = channel::<i32, 4>();
+        let (sender, receiver) = alloc_impl::channel::<i32, 4>();
 
         b.iter(|| {
             let sender = sender.clone();
@@ -412,7 +416,7 @@ mod bench {
 
     #[bench]
     fn bench_overflow(b: &mut Bencher) {
-        let (sender, mut receiver) = channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
 
         b.iter(|| {
             sender.send(1);
@@ -443,7 +447,7 @@ mod bench {
 
     #[bench]
     fn bench_always_overflow(b: &mut Bencher) {
-        let (sender, mut receiver) = channel::<i32, 4>();
+        let (sender, mut receiver) = alloc_impl::channel::<i32, 4>();
 
         b.iter(|| {
             for i in 0..50 {


### PR DESCRIPTION
Added implementation of 'static_mem' which allow using the channel without implementing heap.

This is useful for no_std environments without heap.

Heap implementation is now behind the feature 'alloc' which is enabled by default 